### PR TITLE
PYTHON-4636 Fix windows send/recv perf

### DIFF
--- a/pymongo/lock.py
+++ b/pymongo/lock.py
@@ -71,7 +71,7 @@ class _ALock:
                 return False
             if not blocking:
                 return False
-            await asyncio.sleep(0)
+            await asyncio.sleep(0.001)
 
     def release(self) -> None:
         self._lock.release()
@@ -115,7 +115,7 @@ class _ACondition:
                 return False
             if not blocking:
                 return False
-            await asyncio.sleep(0)
+            await asyncio.sleep(0.001)
 
     async def wait(self, timeout: Optional[float] = None) -> bool:
         """Wait until notified.

--- a/pymongo/lock.py
+++ b/pymongo/lock.py
@@ -71,7 +71,7 @@ class _ALock:
                 return False
             if not blocking:
                 return False
-            await asyncio.sleep(0.001)
+            await asyncio.sleep(0)
 
     def release(self) -> None:
         self._lock.release()
@@ -115,7 +115,7 @@ class _ACondition:
                 return False
             if not blocking:
                 return False
-            await asyncio.sleep(0.001)
+            await asyncio.sleep(0)
 
     async def wait(self, timeout: Optional[float] = None) -> bool:
         """Wait until notified.

--- a/pymongo/network_layer.py
+++ b/pymongo/network_layer.py
@@ -179,18 +179,26 @@ if sys.platform != "win32":
 else:
     # The default Windows asyncio event loop does not support loop.add_reader/add_writer:
     # https://docs.python.org/3/library/asyncio-platforms.html#asyncio-platform-support
+    # Note: In PYTHON-4493 we plan to replace this code with asyncio streams.
     async def _async_sendall_ssl(
         sock: Union[socket.socket, _sslConn], buf: bytes, dummy: AbstractEventLoop
     ) -> None:
         view = memoryview(buf)
         total_length = len(buf)
         total_sent = 0
+        # Backoff starts at 1ms, doubles on timeout up to 512ms, and halves on success
+        # down to 1ms.
+        backoff = 0.001
         while total_sent < total_length:
             try:
                 sent = sock.send(view[total_sent:])
             except BLOCKING_IO_ERRORS:
-                await asyncio.sleep(0.5)
+                await asyncio.sleep(backoff)
                 sent = 0
+            if sent > 0:
+                backoff = max(backoff / 2, 0.001)
+            else:
+                backoff = min(backoff * 2, 0.512)
             total_sent += sent
 
     async def _async_receive_ssl(


### PR DESCRIPTION
Tested on a windows host.

Before:
```
$ pytest test/asynchronous/test_client.py
...
105 passed, 17 skipped, 7 warnings in 129.16s (0:02:09)
```

After:
```
$ pytest test/asynchronous/test_client.py
...
105 passed, 17 skipped, 7 warnings in 86.92s (0:01:26)
```

On master:
```
101 passed, 17 skipped, 7 warnings in 89.99s (0:01:29)
```